### PR TITLE
fix: fixed JSON order independent comparison in DefaultFactoryTest

### DIFF
--- a/gora-mongodb/src/test/java/org/apache/gora/mongodb/filters/DefaultFactoryTest.java
+++ b/gora-mongodb/src/test/java/org/apache/gora/mongodb/filters/DefaultFactoryTest.java
@@ -117,7 +117,6 @@ public class DefaultFactoryTest {
     filter.addFilter(urlFilter);
 
     Bson dbObject = filterFactory.createFilter(filter, store);
-
     JSONObject expectedJSON = new JSONObject("{ \"h.C·T\" : \"text/html\" , \"url\" : \"http://www.example.com\"}");
     JSONObject actualJSON = new JSONObject(asJson(dbObject));
 

--- a/gora-mongodb/src/test/java/org/apache/gora/mongodb/filters/DefaultFactoryTest.java
+++ b/gora-mongodb/src/test/java/org/apache/gora/mongodb/filters/DefaultFactoryTest.java
@@ -18,6 +18,7 @@
 package org.apache.gora.mongodb.filters;
 
 import com.mongodb.MongoClientSettings;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.avro.util.Utf8;
 import org.apache.gora.examples.generated.WebPage;
 import org.apache.gora.filter.FilterList;
@@ -116,8 +117,13 @@ public class DefaultFactoryTest {
     filter.addFilter(urlFilter);
 
     Bson dbObject = filterFactory.createFilter(filter, store);
-    assertEquals(new JSONObject("{ \"h.C·T\" : \"text/html\" , \"url\" : \"http://www.example.com\"}").toString(),
-            new JSONObject(asJson(dbObject)).toString());
+
+    JSONObject expectedJSON = new JSONObject("{ \"h.C·T\" : \"text/html\" , \"url\" : \"http://www.example.com\"}");
+    JSONObject actualJSON = new JSONObject(asJson(dbObject));
+
+    ObjectMapper mapper = new ObjectMapper();
+
+    assertEquals(mapper.readTree(expectedJSON.toString()), mapper.readTree(actualJSON.toString()));
   }
 
   /**


### PR DESCRIPTION
### Description
Test `org.apache.gora.mongodb.filters.DefaultFactoryTest#testCreateFilter_list_2` occasionally fails when the order of fields in  the `JSONObject` objects is different. The current test compares the two `JSONObject` objects by converting them to strings, which is order-sensitive, and could fail when field order differs.


### Steps to reproduce
Run `mvn -pl gora-mongodb edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=org.apache.gora.mongodb.filters.DefaultFactoryTest#testCreateFilter_list_2 -DnondexRuns=10`.


### Expected Behaviour
This test should pass consistently, regardless of the order of fields in the `JSONObject`, as long as the content remains the same.


### Actual Behaviour
The test occasionally fails, raise an exception with error message:
> DefaultFactoryTest.testCreateFilter_list_2:119 expected:<{"[h.C·T":"text/html","url":"http://www.example.com]"}> but was:<{"[url":"http://www.example.com","h.C·T":"text/html]"}>


### Proposed Solution
The solution is to parse both expected and actual `JSONObject` into `JsonNode`, rather than comparing them as strings. Then use Jackson's `ObjectMapper` to compare the two `JsonNode` objects, which ignores the order of the keys.
